### PR TITLE
docs: fix appRole example

### DIFF
--- a/docs/snippets/vault-approle-store.yaml
+++ b/docs/snippets/vault-approle-store.yaml
@@ -18,7 +18,8 @@ spec:
           path: "approle"
           # RoleID configured in the App Role authentication backend
           roleId: "db02de05-fa39-4855-059b-67221c5c2f63"
+          # Reference to a key in a K8 Secret that contains the App Role SecretId
           secretRef:
             name: "my-secret"
             namespace: "secret-admin"
-            key: "vault-token"
+            key: "secret-id"


### PR DESCRIPTION
minor  change for docs page https://external-secrets.io/provider-hashicorp-vault/ to avoid confusing example - secret accepts AppRole SecretId, not a 'vault-token'

[VaultAppRole](https://github.com/external-secrets/external-secrets/blob/e65658d543a759b1d71f2774951f0d473d6201e2/apis/externalsecrets/v1alpha1/secretstore_vault_types.go#L110-L114)